### PR TITLE
Remove ActiveSupport dependency and add test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,19 +2,13 @@ PATH
   remote: .
   specs:
     time_log_robot (0.2.2)
-      activesupport (>= 4.2.6)
-      commander (>= 4.1.6)
-      httparty (>= 0.13.0)
+      commander (~> 4.1, >= 4.1.6)
+      httparty (~> 0.13, >= 0.13.0)
       json (= 1.8.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.0.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
     ansi (1.5.0)
     builder (3.2.2)
     codeclimate-test-reporter (0.6.0)
@@ -22,12 +16,10 @@ GEM
     coderay (1.1.1)
     commander (4.4.0)
       highline (~> 1.7.2)
-    concurrent-ruby (1.0.2)
     docile (1.1.5)
     highline (1.7.8)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
-    i18n (0.7.0)
     json (1.8.1)
     method_source (0.8.2)
     minitest (5.9.0)
@@ -49,9 +41,6 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -64,6 +53,3 @@ DEPENDENCIES
   pry
   rake (~> 10.5)
   time_log_robot!
-
-BUNDLED WITH
-   1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,6 @@ task :console do
   require 'irb/completion'
   require 'pp'
   require 'yaml'
-  require 'active_support'
   require 'httparty'
   Dir[File.expand_path "lib/**/*.rb"].each{|file| require_relative file }
   ARGV.clear

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,6 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require 'minitest/reporters'
 require 'yaml'
-require 'active_support'
 require 'httparty'
 
 Dir[File.expand_path "lib/**/*.rb"].each{|file| require_relative file }

--- a/test/time_log_robot/toggl/report_test.rb
+++ b/test/time_log_robot/toggl/report_test.rb
@@ -1,0 +1,23 @@
+require_relative '../../test_helper'
+
+module TimeLogRobot
+  module Toggl
+    class ReportTest < Minitest::Test
+      def setup
+        @described_class = TimeLogRobot::Toggl::Report
+      end
+
+      def test_since_or_default_with_since
+        since = DateTime.now - 10
+        assert_equal(@described_class.since_or_default(since), since)
+      end
+
+      def test_since_or_default_without_since
+        Date.stub(:today, Date.new(2016,10,18)) do
+          expected_since = Date.new(2016,10,15).to_time
+          assert_equal(@described_class.since_or_default(nil), expected_since)
+        end
+      end
+    end
+  end
+end

--- a/time_log_robot.gemspec
+++ b/time_log_robot.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-reporters', '~> 1.1'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.5'
 
-  spec.add_runtime_dependency 'activesupport', '~> 4.2', '>= 4.2.6'
   spec.add_runtime_dependency 'commander', '~> 4.1', '>= 4.1.6'
   spec.add_runtime_dependency 'httparty', '~> 0.13', '>= 0.13.0'
   spec.add_runtime_dependency 'json', '1.8.1'


### PR DESCRIPTION
Finish #41

This removes the use of beginning_of_week which is an ActiveSupport helper
  method to find the beginning of a week.

Test for the the affected file added and method under test extracted out.
